### PR TITLE
Fix entity_name variable in neutral item shop

### DIFF
--- a/game/dota_addons/dota_duel/scripts/vscripts/neutral_item_shop.lua
+++ b/game/dota_addons/dota_duel/scripts/vscripts/neutral_item_shop.lua
@@ -104,7 +104,7 @@ function PurchaseNeutralItem(item_owner, entity, item_name, use_stash)
     else
       local team = entity:GetTeam()
 
-      local base_entity_name = nil
+      local entity_name
 
       if team == DOTA_TEAM_GOODGUYS then
         entity_name = "base_teleport_radiant"


### PR DESCRIPTION
## Summary
- use `entity_name` as a local variable when dropping items

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c4f66a98832eaed5a7bd2c518e9e